### PR TITLE
Fixed an issue of no default value causing form field to be uncontrolled

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import React from "react";
 
-export default function useLocalStorage(key: string) {
-  const [item, setValue] = React.useState(() => window.localStorage.getItem(key));
+export default function useLocalStorage(key: string, initialValue: string = "") {
+  const [item, setValue] = React.useState(() => window.localStorage.getItem(key) || initialValue);
 
   const setItem = (item: string) => {
     setValue(item);


### PR DESCRIPTION
Initially when there is no Local Storage value initialized with a `key`, following type of error occurs.

```bash
Warning: `value` prop on `input` should not be null. Consider using an empty string to clear the component or `undefined` for uncontrolled components.
    in input (created by App)
    in label (created by App)
    in div (created by App)
    in div (created by App)
    in App
```

This PR fixes the problem above, enabling user to pass an initial value or value is set to an empty string by default to make form field to stay controlled.