### PR TITLE
🛠 Initial value is set in local storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ ReactDOM.render(<App />, rootElement);
 
 # Change Log
 
+2.2.0
+- Sets initial value in local storage
+
 2.1.0
 - Can optionally pass an initial value
 - This is to prevent form field from being uncontrolled.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,10 @@
 import React from "react";
 
 export default function useLocalStorage(key: string, initialValue: string = "") {
-  const [item, setValue] = React.useState(() => window.localStorage.getItem(key) || initialValue);
+  const [item, setValue] = React.useState(() => {
+    localStorage.getItem(key) || localStorage.setItem(key, initialValue); 
+    return initialValue;
+  });
 
   const setItem = (item: string) => {
     setValue(item);


### PR DESCRIPTION
Even with initial value is passed to the hook, items weren't saved in local storage.
This PR fixes it.