### PR TITLE
Refactor useLocalStorage to accept any data type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,16 @@
-import React, { Dispatch } from 'react';
+import { Dispatch, SetStateAction, useState, useEffect } from 'react';
 
-export default function useLocalStorage(
+export default function useLocalStorage<S>(
   key: string,
-  initialValue: string = ''
-): [string, Dispatch<string>] {
-  const [value, setValue] = React.useState(
-    () => localStorage.getItem(key) || initialValue
-  );
+  initialState?: S | (() => S)
+): [S, Dispatch<SetStateAction<S>>] {
+  const item = localStorage.getItem(key);
+  const init = (item === null ? initialState : JSON.parse(item)) as S;
+  const [state, setState] = useState(init);
 
-  React.useEffect(() => {
-    localStorage.setItem(key, value);
-  }, [value]);
+  useEffect(() => {
+    localStorage.setItem(key, JSON.stringify(state));
+  }, [state]);
 
-  return [value, setValue];
+  return [state, setState];
 }


### PR DESCRIPTION
This PR refactors `useLocalStorage` so that it can accept more than just string values.
The function has been modified in the following ways:
- Values are stringified and parsed as needed to be able to be stored in localStorage
- The function is a generic in order to be compatible with any data type/structure
- A null check is added after an item is retrieved from localStorage to avoid unwanted falsey values
  - Example: `localStorage.getItem('emptystring') // => '' (which is falsey)`