### PR TITLE
Watch changes on storage and change state (closes #27)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,14 @@ export default function useLocalStorage(
     window.localStorage.setItem(key, newValue);
   };
 
-  const handleStorageChange = useCallback(
+  useEffect(() => {
+    const newValue = window.localStorage.getItem(key);
+    if (value !== newValue) {
+      setValue(newValue || initialValue);
+    }
+  });
+
+  const handleStorage = useCallback(
     (event: StorageEvent) => {
       if (event.key === key && event.newValue !== value) {
         setValue(event.newValue || initialValue);
@@ -23,10 +30,9 @@ export default function useLocalStorage(
   );
 
   useEffect(() => {
-    window.addEventListener('storage', handleStorageChange);
-
-    return () => window.removeEventListener('storage', handleStorageChange);
-  }, [handleStorageChange]);
+    window.addEventListener('storage', handleStorage);
+    return () => window.removeEventListener('storage', handleStorage);
+  }, [handleStorage]);
 
   return [value, setItem];
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,5 +12,20 @@ export default function useLocalStorage(
     localStorage.setItem(key, value);
   }, [value]);
 
+  const handleStorage = React.useCallback(
+    (event: StorageEvent) => {
+      if (event.key === key && event.newValue !== value) {
+        setValue(event.newValue || initialValue);
+      }
+    },
+    [value]
+  );
+
+  React.useEffect(() => {
+    window.addEventListener('storage', handleStorage);
+
+    return () => window.removeEventListener('storage', handleStorage);
+  }, [handleStorage]);
+
   return [value, setValue];
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,16 +4,13 @@ export default function useLocalStorage(
   key: string,
   initialValue: string = ''
 ): [string, Dispatch<string>] {
-  const [item, setValue] = React.useState(() => {
-    const value = localStorage.getItem(key) || initialValue;
-    localStorage.setItem(key, value);
-    return value;
-  });
+  const [value, setValue] = React.useState(
+    () => window.localStorage.getItem(key) || initialValue
+  );
 
-  const setItem = (newValue: string) => {
-    setValue(newValue);
-    window.localStorage.setItem(key, newValue);
-  };
+  React.useEffect(() => {
+    window.localStorage.setItem(key, value);
+  }, [value]);
 
-  return [item, setItem];
+  return [value, setValue];
 }


### PR DESCRIPTION
I added a listener on storage that runs when modifying storage in another window or tab and an effect that runs on all cycles. Both change state if storage changes occur.

closes #27 