### PR TITLE
package.json main entry should point to commonjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/dance2die/react-use-localstorage.git"
   },
   "homepage": "https://github.com/dance2die/react-use-localstorage",
-  "main": "dist/react-use-localstorage.esm.js",
+  "main": "dist/react-use-localstorage.cjs.production.min.js",
   "umd:main": "dist/react-use-localstorage.umd.production.js",
   "module": "dist/react-use-localstorage.esm.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
Hi,
Currently the entry point is targeting the esm module which somehow makes the library unusable in environments where node_modules are not transpiled (nextjs, cra, ...?).
I think that the main entry should point to the commonjs module.

Thanks.