### PR TITLE
Fix: Use index as main entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/dance2die/react-use-localstorage.git"
   },
   "homepage": "https://github.com/dance2die/react-use-localstorage",
-  "main": "dist/react-use-localstorage.esm.js",
+  "main": "dist/index.js",
   "umd:main": "dist/react-use-localstorage.umd.production.js",
   "module": "dist/react-use-localstorage.esm.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
## Related Issue

Relates to https://github.com/dance2die/react-use-localstorage/issues/43 and https://github.com/dance2die/react-use-localstorage/pull/34

## Context


When importing `react-use-localstorage` with NextJS it throws the error `SyntaxError: Cannot use import statement outside a module`. 

This happens since the change in https://github.com/dance2die/react-use-localstorage/pull/20/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L14

## Proposed Change 

Use `dist/index.js` as the main entry point in `package.json` (it's the default when creating a package with `tsdx create`).